### PR TITLE
Implement contact list and creation activities

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ListaContatosActivity"
+            android:exported="false"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.AgendaFuncionalPROJETOBASE" />
+        <activity
+            android:name=".CadastroContatoActivity"
+            android:exported="false"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.AgendaFuncionalPROJETOBASE" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/agenda/CadastroContatoActivity.kt
+++ b/app/src/main/java/com/example/agenda/CadastroContatoActivity.kt
@@ -1,0 +1,75 @@
+package com.example.agenda
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.agenda.ui.theme.AgendaFuncionalPROJETOBASETheme
+
+class CadastroContatoActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            AgendaFuncionalPROJETOBASETheme {
+                CadastroContatoScreen { nome, telefone, email ->
+                    val dao = ContatoDao(this)
+                    dao.inserir(
+                        Contato(
+                            nome = nome,
+                            telefone = telefone,
+                            email = email,
+                            imagem = "ic_launcher_foreground"
+                        )
+                    )
+                    finish()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CadastroContatoScreen(onSalvar: (String, String, String) -> Unit) {
+    var nome by remember { mutableStateOf("") }
+    var telefone by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        OutlinedTextField(
+            value = nome,
+            onValueChange = { nome = it },
+            label = { Text("Nome") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.size(8.dp))
+        OutlinedTextField(
+            value = telefone,
+            onValueChange = { telefone = it },
+            label = { Text("Telefone") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.size(8.dp))
+        OutlinedTextField(
+            value = email,
+            onValueChange = { email = it },
+            label = { Text("Email") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.size(16.dp))
+        Button(onClick = { onSalvar(nome, telefone, email) }) {
+            Text("Salvar")
+        }
+    }
+}

--- a/app/src/main/java/com/example/agenda/ContatoDbHelper.kt
+++ b/app/src/main/java/com/example/agenda/ContatoDbHelper.kt
@@ -1,3 +1,7 @@
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+
 class ContatoDbHelper(context: Context) : SQLiteOpenHelper(context, "contatos.db", null, 1) {
 
     override fun onCreate(db: SQLiteDatabase) {

--- a/app/src/main/java/com/example/agenda/ListaContatosActivity.kt
+++ b/app/src/main/java/com/example/agenda/ListaContatosActivity.kt
@@ -1,0 +1,85 @@
+package com.example.agenda
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.example.agenda.ui.theme.AgendaFuncionalPROJETOBASETheme
+
+class ListaContatosActivity : ComponentActivity() {
+    private lateinit var dao: ContatoDao
+    private var contatos by mutableStateOf(listOf<Contato>())
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        dao = ContatoDao(this)
+        contatos = dao.listar()
+        enableEdgeToEdge()
+        setContent {
+            AgendaFuncionalPROJETOBASETheme {
+                ListaContatosScreen(contatos) {
+                    startActivity(Intent(this, CadastroContatoActivity::class.java))
+                }
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        contatos = dao.listar()
+    }
+}
+
+@Composable
+fun ListaContatosScreen(contatos: List<Contato>, onAddClick: () -> Unit) {
+    Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(onClick = onAddClick) {
+                Text("+")
+            }
+        }
+    ) { padding ->
+        LazyColumn(modifier = Modifier.padding(padding)) {
+            items(contatos) { contato ->
+                ContatoItem(contato)
+            }
+        }
+    }
+}
+
+@Composable
+fun ContatoItem(contato: Contato) {
+    Row(modifier = Modifier.padding(8.dp)) {
+        val imageRes = painterResource(
+            id = com.example.agenda.R.drawable.ic_launcher_foreground
+        )
+        Image(
+            painter = imageRes,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            contentScale = ContentScale.Crop
+        )
+        Column(modifier = Modifier.padding(start = 8.dp)) {
+            Text(text = contato.nome, style = MaterialTheme.typography.titleMedium)
+            Text(text = contato.telefone)
+            Text(text = contato.email)
+        }
+    }
+}

--- a/app/src/main/java/com/example/agenda/MainActivity.kt
+++ b/app/src/main/java/com/example/agenda/MainActivity.kt
@@ -4,8 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import android.content.Intent
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,9 +21,13 @@ class MainActivity : ComponentActivity() {
         setContent {
             AgendaFuncionalPROJETOBASETheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
+                    MainScreen(
+                        modifier = Modifier.padding(innerPadding),
+                        onOpenList = {
+                            startActivity(
+                                Intent(this@MainActivity, ListaContatosActivity::class.java)
+                            )
+                        }
                     )
                 }
             }
@@ -31,17 +36,20 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
+fun MainScreen(modifier: Modifier = Modifier, onOpenList: () -> Unit) {
+    Column(modifier = modifier.fillMaxSize(), verticalArrangement = Arrangement.Center) {
+        Text(text = "Agenda")
+        Spacer(modifier = Modifier.size(16.dp))
+        Button(onClick = onOpenList) {
+            Text("Ver Contatos")
+        }
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun GreetingPreview() {
     AgendaFuncionalPROJETOBASETheme {
-        Greeting("Android")
+        MainScreen(onOpenList = {})
     }
 }


### PR DESCRIPTION
## Summary
- add SQLite helper imports
- create ListaContatosActivity for viewing stored contacts
- create CadastroContatoActivity for creating new contacts
- update MainActivity to navigate to the contact list
- register new activities in the manifest

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684225e71d448333b9aada13537288b9